### PR TITLE
fix test to use :any and rake file to use generative formatter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,4 @@ RSpec::Core::RakeTask.new
 Generative::RakeTask.new
 
 task :default => :spec
+

--- a/spec/lib/degenerate_spec.rb
+++ b/spec/lib/degenerate_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe Degenerate do
 
   describe "any generator" do
     generative do
-      data(:any) { generate(:array) }
+      data(:any) { generate(:any) }
 
       it "registers an any generator" do
         class_name = any.class.to_s.downcase.to_sym
-        expect(Degenerate::Generators::GENERATORS)
+        expect(Degenerate::Generators::GENERATORS.map{|g| g == :integer ? :fixnum : g})
           .to include(class_name)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,5 @@ require 'generative'
 require 'pry'
 
 RSpec.configure do |config|
+    config.default_formatter =  Generative::Formatter #--tag generative
 end


### PR DESCRIPTION
I noticed the test for "any" was testing array, so I changed it. It fails with "fixnum" not being equal to "interger" so I replaced that in the list of types to look for. 

I changed the Rake file to use the generate formatter so the tests are run several times (as configured by the environment variable "GENERATIVE_COUNT") and output as expected.

use 

> bundle exec rake 
> to test this.
